### PR TITLE
Allow distinct range types in EdgeIterator

### DIFF
--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -57,16 +57,16 @@ map3(f, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 
 ### EdgeIterator ###
 
-struct EdgeIterator{N,UR}
-    outer::CartesianIndices{N,UR}
-    inner::CartesianIndices{N,UR}
-    function EdgeIterator{N,UR}(outer::CartesianIndices{N}, inner::CartesianIndices{N}) where {N,UR}
+struct EdgeIterator{N,UR1,UR2}
+    outer::CartesianIndices{N,UR1}
+    inner::CartesianIndices{N,UR2}
+    function EdgeIterator{N,UR1,UR2}(outer::CartesianIndices{N}, inner::CartesianIndices{N}) where {N,UR1,UR2}
         ((first(inner) ∈ outer) & (last(inner) ∈ outer)) || throw(DimensionMismatch("$inner must be in the interior of $outer"))
         new(outer, inner)
     end
 end
-EdgeIterator(outer::CartesianIndices{N,UR}, inner::CartesianIndices{N,UR}) where {N,UR} =
-    EdgeIterator{N,UR}(outer, inner)
+EdgeIterator(outer::CartesianIndices{N,UR1}, inner::CartesianIndices{N,UR2}) where {N,UR1,UR2} =
+    EdgeIterator{N,UR1,UR2}(outer, inner)
 EdgeIterator(outer::Indices{N}, inner::Indices{N}) where N =
     EdgeIterator(promote(CartesianIndices(outer), CartesianIndices(inner))...)
 
@@ -81,7 +81,7 @@ EdgeIterator
 
 Iterators.IteratorEltype(::Type{<:EdgeIterator}) = Iterators.HasEltype()
 
-Base.eltype(::Type{EdgeIterator{N,UR}}) where {N,UR} = CartesianIndex{N}
+Base.eltype(::Type{EdgeIterator{N,UR1,UR2}}) where {N,UR1,UR2} = CartesianIndex{N}
 Base.length(iter::EdgeIterator) = length(iter.outer) - length(iter.inner)
 
 function Base.iterate(iter::EdgeIterator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,9 @@ end
     @test collect(iter) == []
     @test_throws DimensionMismatch EdgeIterator((1:3,1:1), (1:3,1:2))
     @test_throws DimensionMismatch EdgeIterator((1:3,1:2), (1:4,1:2))
+    iter = EdgeIterator(CartesianIndices((0:4,)), CartesianIndices(1:3))
+    @test collect(iter) == [CartesianIndex(0,),
+                            CartesianIndex(4,)]
 end
 
 @testset "padded sizes" begin


### PR DESCRIPTION
Now that `OneTo` is distinct from `UnitRange`, there are situations where both are passed to `EdgeIterator`.  This is a minor change to allow that.