### PR TITLE
RFC: protect EdgeIterator against bound overrun

### DIFF
--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -95,6 +95,7 @@ function Base.iterate(iter::EdgeIterator, state)
     iterouter = iterate(iter.outer, state)
     iterouter === nothing && return nothing
     item = nextedgeitem(iter, iterouter[2])
+    item ∉ iter.outer && return nothing
     return item, item
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,10 @@ end
     @test collect(iter) == []
     @test_throws DimensionMismatch EdgeIterator((1:3,1:1), (1:3,1:2))
     @test_throws DimensionMismatch EdgeIterator((1:3,1:2), (1:4,1:2))
+    iter = EdgeIterator((Base.OneTo(2),Base.OneTo(3)),(2:2,1:3))
+    for it in iter
+        @test it ∈ iter.outer
+    end
 end
 
 @testset "padded sizes" begin


### PR DESCRIPTION
I am not sure if this is a good idea, since it burdens EdgeIterator for general use.
This change allows ImageFiltering.mapwindow to work with too-skinny domains.
Since such a use is included in the ImageFiltering test suite, maybe this is appropriate.