### PR TITLE
correct EdgeIterator when inner abuts outer at final edge

### DIFF
--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -95,6 +95,7 @@ function Base.iterate(iter::EdgeIterator, state)
     iterouter = iterate(iter.outer, state)
     iterouter === nothing && return nothing
     item = nextedgeitem(iter, iterouter[2])
+    item.I[end] > last(iter.outer.indices[end]) && return nothing
     return item, item
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,14 @@ end
     iter = EdgeIterator(CartesianIndices((0:4,)), CartesianIndices(1:3))
     @test collect(iter) == [CartesianIndex(0,),
                             CartesianIndex(4,)]
+    iter = EdgeIterator((Base.OneTo(2),Base.OneTo(3)),(2:2,1:3))
+    for it in iter
+        @test it ∈ iter.outer
+    end
+    iter = EdgeIterator(CartesianIndices((1:4,)),CartesianIndices((2:4,)))
+    for it in iter
+        @test it ∈ iter.outer
+    end
 end
 
 @testset "padded sizes" begin


### PR DESCRIPTION
This addresses the following issue (which leads to bounds violation in use by `mapwindow` in ImageFiltering):

```julia
julia-0.7> ei=EdgeIterator(CartesianIndices((1:4,)),CartesianIndices((2:4,)))
EdgeIterator((1:4,), (2:4,))

julia-0.7> for it in ei; println(it); end
CartesianIndex(1,)
CartesianIndex(5,) # this should not happen, result is not in ei.outer
```
This violates the implied contract:
```julia
help?> EdgeIterator
search: EdgeIterator

  EdgeIterator(outer, inner)

  A Cartesian iterator that efficiently visits sites that are in outer but not in inner. This can be useful for
  calculating edge values that may require special treatment or boundary conditions.
```
Note the asymmetry at the front end:
```julia
julia-0.7> ei2=EdgeIterator(CartesianIndices((1:4,)),CartesianIndices((1:3,)))
EdgeIterator((1:4,), (1:3,))

julia-0.7> for it in ei2; println(it); end
CartesianIndex(4,)
```

This is a regression from an earlier version:
```julia
julia-0.6> ei=EdgeIterator(CartesianRange((1:4,)),CartesianRange((2:4,)))
TiledIteration.EdgeIterator{1}(CartesianRange{CartesianIndex{1}}(CartesianIndex{1}((1,)), CartesianIndex{1}((4,))), CartesianRange{CartesianIndex{1}}(CartesianIndex{1}((2,)), CartesianIndex{1}((4,))))

julia-0.6> for it in ei; println(it); end
CartesianIndex{1}((1,))
```

The fix is to make the iterator work more like the multidimensional array case in Base.