### PR TITLE
ArrayInterface trait specialization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.2'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,22 @@
 name = "TiledIteration"
 uuid = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
+ArrayInterface = "3"
 Documenter = "0.27"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1"
 julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Documenter"]
+test = ["Test", "Documenter", "LoopVectorization"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,6 +241,9 @@ getoob(v) = @inbounds v[24]
     @test axes(v) == (2:3, 97:99)
     v[2,97] = 1
     @test a[1] == 1
+    @test strides(v) == (1, 2)
+    @test @inferred(TiledIteration.viewtype(typeof(v))) === typeof(v.view)
+    @test @inferred(TiledIteration.buftype(typeof(v))) === typeof(v.buf)
     p = pointer(v)
     v = @inferred(TileBuffer(v, (-1:1, 1:1)))
     @test pointer(v) == p


### PR DESCRIPTION
These changes are needed to support TileBuffer in LoopVectorization.
It contains one breaking change: formerly, `parent(tb::TileBuffer)`
returned the original backing array, whereas now it returns the `view`.
This is more consistent with the fact that the TileBuffer is
equivalent to the view in terms of indexing behavior.

CC @Tokazama, @chriselrod