### PR TITLE
Handle empty `inner` range

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiledIteration"
 uuid = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -80,7 +80,7 @@ Find the next index in `outer` that is not in `inner` if `I` is not an edge site
     # If all of (I2, ..., IN) are in inner, then we can skip iterating I1 ∈ inner1
     # and jump ahead to I1 = last(inner1). On the other hand if any of (I2, ..., IN)
     # are not in inner we keep iterating over I1 ∈ inner1.
-    while I.I[1] == first(iter.inner)[1] && all(map(in, tail(I.I), tail(iter.inner.indices)))
+    while I.I[1] ∈ iter.inner.indices[1] && all(map(in, tail(I.I), tail(iter.inner.indices)))
         state = (last(iter.inner)[1], tail(I.I)...)
         I = CartesianIndex(_inc(state, iter.outer))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,6 +174,14 @@ end
     for it in iter
         @test it ∈ iter.outer
     end
+
+    # empty inner
+    iter = EdgeIterator((1:4,), (3:2,))
+    @test collect(iter) == [CartesianIndex(1),
+                            CartesianIndex(2),
+                            CartesianIndex(3),
+                            CartesianIndex(4),
+                            ]
 end
 
 @testset "padded sizes" begin


### PR DESCRIPTION
When the inner range is empty, all points in the outer range are part
of the edge. Previously, however, the iterator would hang, causing
timeouts for ImageFiltering's test suite.

Example: https://github.com/JuliaImages/ImageFiltering.jl/pull/255