### PR TITLE
Argument check in EdgeIterator inner constructor

### DIFF
--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -25,7 +25,7 @@ struct EdgeIterator{N,UR1,UR2}
     outer::CartesianIndices{N,UR1}
     inner::CartesianIndices{N,UR2}
     function EdgeIterator{N,UR1,UR2}(outer::CartesianIndices{N}, inner::CartesianIndices{N}) where {N,UR1,UR2}
-        ((first(inner) ∈ outer) & (last(inner) ∈ outer)) || throw(DimensionMismatch("$inner must be in the interior of $outer"))
+        issubset(inner, outer) || throw(DimensionMismatch("$inner must be in the interior of $outer"))
         new(outer, inner)
     end
 end


### PR DESCRIPTION
The current inner constructor for `EdgeIterator` throws an error when the inner field is empty:
```julia
julia> inner = CartesianIndices((0,));

julia> outer = CartesianIndices((1,));

julia> EdgeIterator(outer, inner)
ERROR: DimensionMismatch: CartesianIndices((0,)) must be in the interior of CartesianIndices((1,))

```

Fix calls `issubset` instead.